### PR TITLE
Fix a typo in meta file

### DIFF
--- a/.meta
+++ b/.meta
@@ -16,7 +16,7 @@
     "aws/modules/tf_aws_bastion_s3_keys_tmp": "https://github.com/robc-io/tf_aws_bastion_s3_keys_tmp",
     "aws/modules/terraform-aws-icon-peering-mgmt": "https://github.com/robc-io/terraform-aws-icon-peering-mgmt",
     "aws/modules/terraform-aws-icon-nlb": "https://github.com/robc-io/terraform-aws-icon-nlb",
-    "aws/modules/terraform-aws-icon-node-configuration": "https://github.com/anocendi/terraform-aws-icon-node-configuration"
+    "aws/modules/terraform-aws-icon-node-configuration": "https://github.com/anocendi/terraform-aws-icon-node-configuration",
     "scripts/icon-prep-network-setup": "https://github.com/block42-blockchain-company/icon-prep-network-setup",
     "scripts/rhizome-node-toolbox": "https://github.com/rhizomeicx/rhizome-node-toolbox"
   }


### PR DESCRIPTION
The new entry needs a comma.

Signed-off-by: Soe San Win <soe.san.win.oss@gmail.com>